### PR TITLE
Name SSH host for github "github.com"

### DIFF
--- a/git-ssh.sh
+++ b/git-ssh.sh
@@ -29,7 +29,7 @@ eval "$(ssh-agent -s)" > /dev/null
 # to automatically load keys
 echo "
 
-Host *
+Host github.com
   AddKeysToAgent yes
   IdentityFile ~/.ssh/github-prime
 


### PR DESCRIPTION
Resolves #7 

I'm actually not at all sure if this is the correct solve here. Or would we want to change the `Hostname` property of this config section? It seems like the `Host` property is just an alias for this configuration group.

FWIW, I can remove this section entire from my ssh config, and git still works. But maybe it's a "run once and your done" kind of thing? Because it works without this section, I can't really test if this change breaks anything

@kdszafranski what were you seeing in #7 that was making you think using `Host *` was breaking something?