### PR TITLE
fix typo in postmaster.pid filename

### DIFF
--- a/postgres-troubleshooting.md
+++ b/postgres-troubleshooting.md
@@ -53,7 +53,7 @@ Postgres sometimes has trouble if your computer shuts down unexpectedly (eg, out
 Try:
 
 ```
-ls /usr/local/var/postgres/postmaster.id
+ls /usr/local/var/postgres/postmaster.pid
 
 # or
 


### PR DESCRIPTION
Just this one lil' character:
<img width="1378" alt="Screen Shot 2022-03-18 at 10 27 24 AM" src="https://user-images.githubusercontent.com/5817534/159032451-27b7d732-b458-487d-93ff-376ef46f8e5c.png">
